### PR TITLE
Fix the config to use AAT environment

### DIFF
--- a/TestFramework/Properties/launchSettings.json
+++ b/TestFramework/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "environmentVariables": {
         "BROWSER": "Chrome",
-        "ENVIRONMENT": "Development"
+        "ENVIRONMENT": "Acceptance"
       },
       "sqlDebugging": true,
       "nativeDebugging": true

--- a/UI/Selenium/Properties/launchSettings.json
+++ b/UI/Selenium/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "environmentVariables": {
         "BROWSER": "Chrome",
-        "ENVIRONMENT": "Development"
+        "ENVIRONMENT": "Acceptance"
       },
       "sqlDebugging": true,
       "nativeDebugging": true

--- a/UI/Selenium/Utilities/EnvironmentConfigSettings.cs
+++ b/UI/Selenium/Utilities/EnvironmentConfigSettings.cs
@@ -12,6 +12,7 @@
         public string OneMinuteElementWait { get; set; }
         public string VideoUrl { get; set; }
         public string AdminUrl { get; set; }
+        public string ServiceUrl { get; set; }
 
     }
 }

--- a/UI/Selenium/Utilities/SystemConfiguration.cs
+++ b/UI/Selenium/Utilities/SystemConfiguration.cs
@@ -3,7 +3,7 @@
     public class SystemConfiguration
     {
         public EnvironmentConfigSettings DevelopmentEnvironmentConfigSettings { get; set; }
-        public EnvironmentConfigSettings StagingEnvironmentConfigSettings { get; set; }
+        public EnvironmentConfigSettings AcceptanceEnvironmentConfigSettings { get; set; }
         public EnvironmentConfigSettings ProductionEnvironmentConfigSettings { get; set; }
     }
 }

--- a/UI/Selenium/Utilities/TestConfigHelper.cs
+++ b/UI/Selenium/Utilities/TestConfigHelper.cs
@@ -38,9 +38,9 @@ namespace TestLibrary.Utilities
                 {
                     return systemConfiguration.DevelopmentEnvironmentConfigSettings;
                 }
-                else if (environment.ToLower() == "QA".ToLower())
+                else if (environment.ToLower() == "Acceptance".ToLower())
                 {
-                    return systemConfiguration.StagingEnvironmentConfigSettings;
+                    return systemConfiguration.AcceptanceEnvironmentConfigSettings;
                 }
                 else if (environment.ToLower() == "Production".ToLower())
                 {

--- a/UI/Selenium/appsettings.json
+++ b/UI/Selenium/appsettings.json
@@ -44,24 +44,21 @@
       "BambooEmail": "auto_aw.videohearingsofficer_01@hearings.reform.hmcts.net",
       "AdminUrl": "https://vh-admin-web-dev.hearings.reform.hmcts.net",
       "VideoUrl": "https://vh-video-web-dev.hearings.reform.hmcts.net",
-      "ServiceUrl": "",
+      "ServiceUrl": "https://vh-Service-web-dev.hearings.reform.hmcts.net",
       "SoapApiUrl": "http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso",
       "DefaultElementWait": "20",
       "OneMinuteElementWait": "60"
     },
-
-    "StagingEnvironmentConfigSettings": {
-      "environment": "QA",
+    "AcceptanceEnvironmentConfigSettings": {
+      "environment": "Acceptance",
       "connectionString": "Host=localhost;Username=test;Password=test123;Database=Test_WebDb",
-      "URL": "https://spahostingdapx.z6.web.core.windows.net/",
-      "BambooURL": "https://version1sandbox.bamboohr.com",
-      "BambooEmail": "bikash.test@version1.com",
-      "BambooPassword": "Rocky@097292",
-      "ApiUrl": "shobhit.test@version1.com",
+      "BambooEmail": "auto_aw.videohearingsofficer_01@hearings.reform.hmcts.net",
+      "AdminUrl": "https://vh-admin-web-aat.hearings.reform.hmcts.net",
+      "VideoUrl": "https://vh-video-web-aat.hearings.reform.hmcts.net",
+      "ServiceUrl": "https://vh-service-web-aat.hearings.reform.hmcts.net",
       "SoapApiUrl": "http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso",
-      "VideoUrl": "",
       "DefaultElementWait": "20",
-      "OneMinuteElementWait": "60"
+      "OneMinuteElementWait": "90"
     },
 
     "ProductionEnvironmentConfigSettings": {


### PR DESCRIPTION
Updates made to support a new environment - Acceptance / AAT

(Config needs to be changed - appsettings could have any number of environments defined, the app should read any one based on the setting chosen in launch settings.  For hmcts there is dev / test 1/ test 2/ preprod / aat / demo - we don't know which environments that we could be working on.)