### PR TITLE
Save the screenshot images in the format <scenariotitle><000x> 

### DIFF
--- a/UI/Selenium/Hooks/Hooks.cs
+++ b/UI/Selenium/Hooks/Hooks.cs
@@ -80,6 +80,7 @@ namespace SeleniumSpecFlow
         {
             var scenarioTitle = scenarioContext.ScenarioInfo.Title;
             Logger.Info($"Starting scenario '{scenarioTitle}'");
+            ImageNumber=0;
         }
         
         [BeforeScenario("web")]

--- a/UI/Selenium/Hooks/Hooks.cs
+++ b/UI/Selenium/Hooks/Hooks.cs
@@ -36,6 +36,7 @@ namespace SeleniumSpecFlow
         private static string filePath;
         private static Logger Logger = LogManager.Setup().LoadConfigurationFromAppSettings().GetCurrentClassLogger();
         private static string featureTitle;
+        private static int ImageNumber=0;
         [BeforeTestRun]
         public static void BeforeTestRun()
         {
@@ -147,7 +148,9 @@ namespace SeleniumSpecFlow
         public static void InsertReportingStepsWeb(ScenarioContext scenarioContext)
         {
             var driver = (IWebDriver)scenarioContext["driver"];
-            var ScreenshotFilePath = Path.Combine(ProjectPath + ImagesPath, Path.GetFileNameWithoutExtension(Path.GetTempFileName()) + ".png");
+            var imageNumberStr = (++ImageNumber).ToString("D4");
+            var imageFileName = $"{scenarioContext.ScenarioInfo.Title.Replace(" ","_")}{imageNumberStr}";
+            var ScreenshotFilePath = Path.Combine(ProjectPath + ImagesPath, $"{imageFileName}.png");
             var mediaModel = MediaEntityBuilder.CreateScreenCaptureFromPath(ScreenshotFilePath).Build();
 
             if (scenarioContext.TestError != null && !(scenarioContext.TestError is AssertionException))
@@ -188,7 +191,6 @@ namespace SeleniumSpecFlow
 
                 driver.TakeScreenshot().SaveAsFile(ScreenshotFilePath, ScreenshotImageFormat.Png);
                 Logger.Info($"Screenshot has been saved to {ScreenshotFilePath}");
-                driver.TakeScreenshot().SaveAsFile(ScreenshotFilePath, ScreenshotImageFormat.Png);
 
                 switch (ScenarioStepContext.Current.StepInfo.StepDefinitionType)
                 {
@@ -245,11 +247,6 @@ namespace SeleniumSpecFlow
                         _scenario.CreateNode<Then>(ScenarioStepContext.Current.StepInfo.Text).Pass(string.Empty, mediaModel);
                         break;
                 }
-
-                // For Living Doc
-                filePath = Path.Combine(ProjectPath + ImagesPath, Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) + ".png");
-                driver.TakeScreenshot().SaveAsFile(filePath, ScreenshotImageFormat.Png);
-                Logger.Info($"Screenshot has been saved to {filePath}");
 
                 _specFlowOutputHelper.WriteLine("Logging Using Specflow");
                 _specFlowOutputHelper.AddAttachment(filePath);


### PR DESCRIPTION
images are saved with the file name format
scenariotitle000X where X is integer number incremented by 1. The number is left padded with 0s for 4 digits. 
The integer always starts with 1 for a scenario.

For example Judge_invites_the_participant_to_join_the_consultation_room0002.png