### PR TITLE
Fix the issue where some of the browser processes are left out

### DIFF
--- a/TestFramework/TestFramework.csproj
+++ b/TestFramework/TestFramework.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 	<PackageReference Include="NLog" Version="4.7.13" />
 	<PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
+	<PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="Selenium.Support" Version="4.1.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />

--- a/UI/Selenium/Hooks/Hooks.cs
+++ b/UI/Selenium/Hooks/Hooks.cs
@@ -33,7 +33,6 @@ namespace SeleniumSpecFlow
         private static ExtentTest _feature;
         private static ExtentTest _scenario;
         private static ExtentReports _extent;
-        private static ISpecFlowOutputHelper _specFlowOutputHelper;
         private static Logger Logger = LogManager.Setup().LoadConfigurationFromAppSettings().GetCurrentClassLogger();
         private static string featureTitle;
         private static int ImageNumber=0;
@@ -76,8 +75,6 @@ namespace SeleniumSpecFlow
             _feature = _extent.CreateTest<Feature>(featureTitle);
 
             Logger.Info($"Starting feature '{featureTitle}'");
-
-            //_specFlowOutputHelper = outputHelper;
         }
 
         [BeforeScenario]
@@ -252,9 +249,6 @@ namespace SeleniumSpecFlow
                         _scenario.CreateNode<Then>(scenarioContext.StepContext.StepInfo.Text).Pass(string.Empty, mediaModel);
                         break;
                 }
-
-                //_specFlowOutputHelper.WriteLine("Logging Using Specflow");
-                //_specFlowOutputHelper.AddAttachment(ScreenshotFilePath);
             }
         }
 
@@ -322,7 +316,7 @@ namespace SeleniumSpecFlow
             var drivers = (Dictionary<string, IWebDriver>)scenarioContext["drivers"];
             foreach(var driver in drivers)
             {
-                browserName=$@"{((WebDriver)driver.Value).Capabilities["browserName"]}.exe";
+                browserName=$@"{((WebDriver)driver.Value).Capabilities["browserName"]}";
                 driver.Value.Quit();
                 driver.Value.Dispose();
                 Logger.Info("Driver has been closed");
@@ -345,7 +339,7 @@ namespace SeleniumSpecFlow
                 {
                     if (scenarioContext.ContainsKey("driver"))
                     {
-                        browserName=$@"{((WebDriver)driver.Value).Capabilities["browserName"]}.exe";
+                        browserName=$@"{((WebDriver)driver.Value).Capabilities["browserName"]}";
                         driver.Value?.Quit();
                         driver.Value?.Dispose();
                         Logger.Info($"Driver has been closed");
@@ -355,7 +349,7 @@ namespace SeleniumSpecFlow
             else
             {
                 var driver = (IWebDriver)scenarioContext["driver"];
-                browserName=$@"{((WebDriver)driver).Capabilities["browserName"]}.exe";
+                browserName=$@"{((WebDriver)driver).Capabilities["browserName"]}";
                 driver.Quit();
                 driver.Dispose();
                 Logger.Info($"Driver has been closed");
@@ -396,12 +390,19 @@ namespace SeleniumSpecFlow
 
         private static void KillAllBrowserInstances(string processName)
         {
-            var processes = Process.GetProcessesByName(processName);
-            foreach(var process in processes)
+            var processes = Process.GetProcesses().Where(p => p.ProcessName.ToLowerInvariant().Contains(processName.ToLowerInvariant()));
+            foreach (var process in processes)
             {
-                if(process.StartTime > TestStartTime)
+                try
                 {
-                    process.Kill(true);
+                    if (process.StartTime > TestStartTime)
+                    {
+                        process.Kill(true);
+                    }
+                }
+                catch (InvalidOperationException)
+                {
+                    continue;
                 }
             }
         }

--- a/UI/Selenium/Steps/ConsultationRoomSteps.cs
+++ b/UI/Selenium/Steps/ConsultationRoomSteps.cs
@@ -134,7 +134,8 @@ namespace UI.Steps
             scriptExecutor.ExecuteScript(script);
             ExtensionMethods.FindElementWithWait(Driver, ConsultationRoomPage.ConfirmLeaveButton, _scenarioContext).Click();
 
-            Driver.FindElement(ParticipantWaitingRoomPage.ParticipantDetails($"{participant.Name.FirstName} {participant.Name.LastName}")).Displayed.Should().BeTrue();
+            Driver.IsDisplayed(ParticipantWaitingRoomPage.ParticipantDetails($"{participant.Name.FirstName} {participant.Name.LastName}")
+                           , _scenarioContext, TimeSpan.FromSeconds(Config.DefaultElementWait));
 
             ExtensionMethods.FindElementWithWait(Driver, ParticipantWaitingRoomPage.ParticipantDetails(_hearing.Case.CaseNumber), _scenarioContext, TimeSpan.FromSeconds(Config.DefaultElementWait)).Displayed.Should().BeTrue();
             Driver.FindElement(ParticipantWaitingRoomPage.ChooseCameraAndMicButton).Displayed.Should().BeTrue();
@@ -216,8 +217,7 @@ namespace UI.Steps
             Driver.SwitchTo().ActiveElement();
             var modelDialog = Driver.FindElement(ParticipantWaitingRoomPage.PrivateMeetingModal);
 
-            var checkbox = modelDialog.FindElement(ParticipantWaitingRoomPage.JointPrivateMeetingCheckbox(secondParticipant.Name.FirstName));
-            checkbox.Click();
+            modelDialog.RetryClick(ParticipantWaitingRoomPage.JointPrivateMeetingCheckbox(secondParticipant.Name.FirstName));
 
             modelDialog.FindElement(ParticipantWaitingRoomPage.ContinueJoiningPrivateMeetingButton).Click();
 

--- a/UI/Selenium/Steps/HearingListSteps.cs
+++ b/UI/Selenium/Steps/HearingListSteps.cs
@@ -46,7 +46,7 @@ namespace UI.Steps
             Driver = GetDriver(participant, _scenarioContext);
             _scenarioContext["driver"] = Driver;
             Driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(Config.DefaultElementWait);
-            ExtensionMethods.FindElementWithWait(Driver, ParticipantHearingListPage.SelectButton(_hearing.Case.CaseNumber), _scenarioContext, TimeSpan.FromSeconds(Config.DefaultElementWait)).Click();
+            Driver.RetryClick(ParticipantHearingListPage.SelectButton(_hearing.Case.CaseNumber), _scenarioContext, TimeSpan.FromSeconds(Config.DefaultElementWait));
             if (!(participant.ToLower().Contains("judge") || participant.ToLower().Contains("panel")))
             {
                 Driver.FindElement(ParticipantHearingListPage.ButtonNext).Click();
@@ -54,7 +54,7 @@ namespace UI.Steps
                 Driver.FindElement(ParticipantHearingListPage.SwitchOnButton).Click();
                 Driver.FindElement(ParticipantHearingListPage.WatchVideoButton).Click();
                 // Assert video is playing
-                Driver.FindElement(ParticipantHearingListPage.ContinueButton).Click();
+                Driver.RetryClick(ParticipantHearingListPage.ContinueButton,_scenarioContext,TimeSpan.FromSeconds(Config.DefaultElementWait));
                 if (SkipPracticeVideoHearingDemo)
                 {
                     string cameraUrl = Driver.Url.Replace("practice-video-hearing", "camera-working");


### PR DESCRIPTION
This branch contains following fixes
1. Properly close all instances of browser processes at the end of scenario
2. Added few extension methods to IWebDriver, IWebElement to retry the operations like Click() when StaleElementException and other exception occurs. This helps to reduce the flakiness of the tests that occurs due to slow response of server or test execution environment