### PR TITLE
improve accessibility tests

### DIFF
--- a/UI/Selenium/Steps/AccessibilitySteps_ParticipantsHearingSignIn.cs
+++ b/UI/Selenium/Steps/AccessibilitySteps_ParticipantsHearingSignIn.cs
@@ -16,6 +16,7 @@ namespace UI.Steps
         private DashboardSteps dashboardSteps;
         private AxeBuilder axeResult;
         AccessibilitySteps_VideoBooking accessibilitySteps;
+        BookingListSteps bookingListSteps;
         public string username = "auto_vw.individual_05@hearings.reform.hmcts.net";
         string _pageName;
         Hearing _hearing;
@@ -25,6 +26,7 @@ namespace UI.Steps
             _scenarioContext = scenarioContext;
             loginSteps = new LoginPageSteps(scenarioContext);
             dashboardSteps = new DashboardSteps(scenarioContext);
+            bookingListSteps = new BookingListSteps(scenarioContext);
             accessibilitySteps = new AccessibilitySteps_VideoBooking(scenarioContext);
             axeResult = new AxeBuilder(Driver);
         }
@@ -33,9 +35,8 @@ namespace UI.Steps
         public void GivenAnIndividualOnThePage(string pageName)
         {
             _pageName = pageName;
-            accessibilitySteps.GivenImOnThePage("Booking Details");
-            accessibilitySteps.ThenThePageShouldBeAccessible();
-            RetryBookingConfirmationIfFails();
+            accessibilitySteps.PageName = pageName;
+            bookingListSteps.GivenIHaveABookedHearingInNextMinutes(3);
             _hearing = (Hearing)_scenarioContext["Hearing"];
             loginSteps.LoginUrl = Config.VideoUrl;
         }
@@ -53,27 +54,27 @@ namespace UI.Steps
             {
                 case "Hearing List":
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.CheckEquipment);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
 
                 case "Introduction":
                     ProceedToPage("Hearing List");
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.SelectButton(_hearing.Case.CaseNumber)).Click();
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
 
                 case "Equipment-Check":
                     ProceedToPage("Introduction");
                     Driver.FindElement(ParticipantHearingListPage.ButtonNext).Click();
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.ContinueButton);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
 
                 case "Switch-On-Camera-Microphone":
                     ProceedToPage("Equipment-Check");
                     Driver.FindElement(ParticipantHearingListPage.ContinueButton).Click();
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.SwitchOnButton);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
 
                 case "Camera-Working":
@@ -83,14 +84,14 @@ namespace UI.Steps
                     Driver.Navigate().GoToUrl(url);
                     Driver.SwitchTo().Alert().Accept();
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.CameraWorkingYes);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
                 case "Microphone-Working":
                     ProceedToPage("Camera-Working");
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.CameraWorkingYes).Click();
                     Driver.FindElement(ParticipantHearingListPage.ContinueButton).Click();
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.MicrophoneWorkingYes);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
 
                 case "See-And-Hear-Video":
@@ -98,27 +99,27 @@ namespace UI.Steps
                     Driver.FindElement(ParticipantHearingListPage.MicrophoneWorkingYes).Click();
                     Driver.FindElement(ParticipantHearingListPage.ContinueButton).Click();
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.VideoWorkingYes);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
                 case "Hearing-Rules":
                     ProceedToPage("See-And-Hear-Video");
                     Driver.FindElement(ParticipantHearingListPage.VideoWorkingYes).Click();
                     Driver.FindElement(ParticipantHearingListPage.ContinueButton).Click();
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.NextButton);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
                 case "Declaration":
                     ProceedToPage("Hearing-Rules");
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.NextButton).Click();
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantHearingListPage.DeclareCheckbox);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
                 case "Waiting Room":
                     ProceedToPage("Declaration");
                     Driver.FindElement(ParticipantHearingListPage.DeclareCheckbox).Click();
                     Driver.FindElement(ParticipantHearingListPage.NextButton).Click();
                     ExtensionMethods.FindElementEnabledWithWait(Driver, ParticipantWaitingRoomPage.ChooseCameraAndMicButton);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    accessibilitySteps.AxeAnalyze(pageName);
                     break;
             }
         }

--- a/UI/Selenium/Steps/AccessibilitySteps_VideoBooking.cs
+++ b/UI/Selenium/Steps/AccessibilitySteps_VideoBooking.cs
@@ -96,7 +96,7 @@ namespace UI.Steps
                     table = StepsHelper.Set.ParticipantsData();
                     participantsSteps.GivenIWantToCreateAHearingFor(table);
                     ExtensionMethods.GetSelectElementWithText(Driver, VideoAccessPointsPage.DefenceAdvocate(0), "None", _scenarioContext);
-                    AxeAnalyze(pageName); //THIS IS CURRENTLY FAILING- UNCOMMENT LATER
+                    AxeAnalyze(pageName);
                     break;
                 case "Other Information":
                     ProceedToPage("Video Access Points");
@@ -117,14 +117,14 @@ namespace UI.Steps
                     ProceedToPage("Summary");
                     summaryPageSteps.GivenIBookTheHearing();
                     summaryPageSteps.ThenAHearingShouldBeCreated();
-                    AxeAnalyze(pageName); // AXE VIOLATIONS ON THIS PAGE
+                    AxeAnalyze(pageName);
                     break;
                 case "Booking Details":
                     ProceedToPage("Booking Confirmation");
                     WebDriverWait wait = new WebDriverWait(Driver, TimeSpan.FromSeconds(int.Parse(Config.OneMinuteElementWait)));
                     wait.Until(ExpectedConditions.InvisibilityOfElementLocated(SummaryPage.DotLoader));
                     ExtensionMethods.FindElementWithWait(Driver, BookingDetailsPage.BookingConfirmedStatus, _scenarioContext);
-                    AxeAnalyze(pageName); // AXE VIOLATIONS ON THIS PAGE => Ensures every id attribute value is unique
+                    AxeAnalyze(pageName);
                     break;
                 case "Booking List":
                     ExtensionMethods.FindElementWithWait(Driver, Header.BookingsList, _scenarioContext).Click();

--- a/UI/Selenium/Steps/AccessibilitySteps_VideoBooking.cs
+++ b/UI/Selenium/Steps/AccessibilitySteps_VideoBooking.cs
@@ -11,6 +11,7 @@ using OpenQA.Selenium.Support.UI;
 using SeleniumExtras.WaitHelpers;
 using System;
 using UI.Utilities;
+using OpenQA.Selenium;
 namespace UI.Steps
 {
     [Binding]
@@ -39,8 +40,6 @@ namespace UI.Steps
             participantsSteps = new ParticipantsSteps(scenarioContext);
             videoAccessSteps = new VideoAccessSteps(scenarioContext);
             otherInformationSteps = new OtherInformationSteps(scenarioContext);
-            summaryPageSteps = new SummaryPageSteps(scenarioContext);
-            axeResult = new AxeBuilder(Driver);
         }
 
         [Given(@"I'm on the ""([^""]*)"" page")]
@@ -59,12 +58,11 @@ namespace UI.Steps
         private void CheckAccessibilityCompliance(string pageName)
         {
             ExtensionMethods.FindElementWithWait(Driver, DashboardPage.BookHearingButton, _scenarioContext);
-            axeResult.Analyze().Violations.Should().BeEmpty();
             switch(pageName)
             {
                 case "Hearing Details":
                     dashboardSteps.GivenISelectBookAHearing();
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
 
                 case "Hearing Schedule":
@@ -72,7 +70,7 @@ namespace UI.Steps
                     var table = StepsHelper.Set.HearingDetailsData();
                     createHearingDetails.GivenIWantToCreateAHearingWithCaseDetails(table);
                     ExtensionMethods.FindElementWithWait(Driver, HearingSchedulePage.HearingDate, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
 
                 case "AssignJudge":
@@ -81,7 +79,7 @@ namespace UI.Steps
                     table = StepsHelper.Set.HearingScheduleData();
                     hearingScheduleSteps.GivenTheHearingHasTheFollowingScheduleDetails(table);
                     ExtensionMethods.FindElementWithWait(Driver, HearingAssignJudgePage.JudgeEmail, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
 
                 case "Participants":
@@ -90,7 +88,7 @@ namespace UI.Steps
                     table = StepsHelper.Set.JudgeData();
                     hearingAssignJudgeSteps.GivenIWantToAssignAJudgeWithCourtroomDetails(table);
                     new SelectElement(ExtensionMethods.FindElementWithWait(Driver, ParticipantsPage.PartyDropdown, _scenarioContext));
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
 
                 case "Video Access Points":
@@ -98,14 +96,14 @@ namespace UI.Steps
                     table = StepsHelper.Set.ParticipantsData();
                     participantsSteps.GivenIWantToCreateAHearingFor(table);
                     ExtensionMethods.GetSelectElementWithText(Driver, VideoAccessPointsPage.DefenceAdvocate(0), "None", _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty(); //THIS IS CURRENTLY FAILING- UNCOMMENT LATER
+                    AxeAnalyze(pageName); //THIS IS CURRENTLY FAILING- UNCOMMENT LATER
                     break;
                 case "Other Information":
                     ProceedToPage("Video Access Points");
                     table = StepsHelper.Set.VideoAccessPointData();
                     videoAccessSteps.GivenWithVideoAccessPointsDetails(table);
                     ExtensionMethods.FindElementWithWait(Driver, OtherInformationPage.OtherInfo, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
 
                 case "Summary":
@@ -113,53 +111,49 @@ namespace UI.Steps
                     table = StepsHelper.Set.SetOtherInfoData();
                     otherInformationSteps.GivenISetAnyOtherInformation(table);
                     ExtensionMethods.FindElementWithWait(Driver, SummaryPage.BookButton, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
                 case "Booking Confirmation":
                     ProceedToPage("Summary");
                     summaryPageSteps.GivenIBookTheHearing();
                     summaryPageSteps.ThenAHearingShouldBeCreated();
-                    axeResult.Analyze().Violations.Should().BeEmpty(); // AXE VIOLATIONS ON THIS PAGE
+                    AxeAnalyze(pageName); // AXE VIOLATIONS ON THIS PAGE
                     break;
                 case "Booking Details":
                     ProceedToPage("Booking Confirmation");
-                    ExtensionMethods.FindElementWithWait(Driver, BookingConfirmationPage.ViewBookingLink, _scenarioContext).Click();
-                    ExtensionMethods.FindElementWithWait(Driver, BookingDetailsPage.ConfirmBookingButton, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
-                    ExtensionMethods.FindElementWithWait(Driver, BookingDetailsPage.ConfirmBookingButton, _scenarioContext).Click();
                     WebDriverWait wait = new WebDriverWait(Driver, TimeSpan.FromSeconds(int.Parse(Config.OneMinuteElementWait)));
                     wait.Until(ExpectedConditions.InvisibilityOfElementLocated(SummaryPage.DotLoader));
                     ExtensionMethods.FindElementWithWait(Driver, BookingDetailsPage.BookingConfirmedStatus, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty(); // AXE VIOLATIONS ON THIS PAGE => Ensures every id attribute value is unique
+                    AxeAnalyze(pageName); // AXE VIOLATIONS ON THIS PAGE => Ensures every id attribute value is unique
                     break;
                 case "Booking List":
                     ExtensionMethods.FindElementWithWait(Driver, Header.BookingsList, _scenarioContext).Click();
                     ExtensionMethods.FindElementWithWait(Driver, BookingListPage.VideoHearingsTable, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
                 case "Questionnaire":
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.QuestionnaireResultsButton, _scenarioContext).Click();
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.QuestionairVHTable, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
                 case "Get-Audio-File":
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.GetAudioFileLinkButton, _scenarioContext).Click();
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.CaseNumber, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
                 case "Change-User-Password":
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.ChangeUserPasswordButton, _scenarioContext).Click();
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.UserName, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
                 case "Delete-User-Account":
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.DeleteParticipantButton, _scenarioContext).Click();
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
                 case "Edit-Participant-Name":
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.EditPparticipantNameButton, _scenarioContext).Click();
                     ExtensionMethods.FindElementWithWait(Driver, DashboardPage.ContactEmail, _scenarioContext);
-                    axeResult.Analyze().Violations.Should().BeEmpty();
+                    AxeAnalyze(pageName);
                     break;
             }
         }
@@ -167,6 +161,15 @@ namespace UI.Steps
         private void ProceedToPage(string pageName)
         {
             CheckAccessibilityCompliance(pageName);
+        }
+
+        public void AxeAnalyze(string pageToAnalyse)
+        {
+            if(pageToAnalyse == PageName)
+            {
+                axeResult = new AxeBuilder((IWebDriver)_scenarioContext["driver"]);
+                axeResult.Analyze().Violations.Should().BeEmpty();
+            }
         }
     }
 }

--- a/UI/Selenium/Steps/LoginPageSteps.cs
+++ b/UI/Selenium/Steps/LoginPageSteps.cs
@@ -48,7 +48,7 @@ namespace SeleniumSpecFlow.Steps
         [Given(@"I log in as ""([^""]*)""")]
         public void GivenILogInAs(string userName)
         {
-            LoginByUrl(userName, Config.AdminUrl);
+            LoginByUrl(userName, LoginUrl);
         }
 
         private void LoginByUrl(string userName, string url)


### PR DESCRIPTION
Because of re-usability of the code, ie each flow shares some steps from another. This meant Axe was analysing each and every page, and this meant accessibility tests were taking forever to execute. 
Axe should only analyze the intended page ie if the flow goes like page-1 -> Page-2 -> Page-3 : and I want to analyze Page-3, Axe should not execute for Page-1 or Page-2... This PR fixes that