### PR TITLE
VIH-9588 use vstest to run UI tests to support reruns for failed tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 *.sln.docstates
 *.feature.cs
 
-
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
@@ -346,3 +345,7 @@ healthchecksdb
 *passwords.json
 /azure-pipelines.nightly.yml
 /azure-pipelines.release.yml
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -70,9 +70,10 @@ stages:
       #     projects: '$(projectPath)/*.csproj'
       #     arguments: '--configuration Release'
 
-      - task: MSBuild@1
+      - task: VSBuild@1
+        displayName:  Build UI Tests
         inputs:
-          solution: '$(projectPath)/*.csproj'
+          solution: '**\*.sln'
           configuration: 'Release'
           restoreNugetPackages: true
       

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -55,13 +55,13 @@ stages:
           Get-Content "$(projectPath)/appsettings.json"
         displayName: Print App Settings
 
-      # - task: DotNetCoreCLI@2
-      #   displayName:  Run UI Tests
-      #   inputs:
-      #     command: test
-      #     projects: '$(projectPath)/*.csproj'
-      #     arguments: '--configuration Release'
-      #     publishTestResults: true
+      - task: DotNetCoreCLI@2
+        displayName:  Run UI Tests
+        inputs:
+          command: test
+          projects: '$(projectPath)/*.csproj'
+          arguments: '--configuration Release'
+          publishTestResults: true
 
       # - task: DotNetCoreCLI@2
       #   displayName:  Build UI Tests
@@ -69,13 +69,6 @@ stages:
       #     command: 'build'
       #     projects: '$(projectPath)/*.csproj'
       #     arguments: '--configuration Release'
-
-      - task: VSBuild@1
-        displayName:  Build UI Tests
-        inputs:
-          solution: '**\*.sln'
-          configuration: 'Release'
-          restoreNugetPackages: true
       
       - task: VisualStudioTestPlatformInstaller@1
         displayName: Run VS Test Installer

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -58,7 +58,7 @@ stages:
       - task: DotNetCoreCLI@2
         displayName:  Run UI Tests
         inputs:
-          command: test
+          command: build
           projects: '$(projectPath)/*.csproj'
           arguments: '--configuration Release'
           publishTestResults: true

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -63,12 +63,21 @@ stages:
       #     arguments: '--configuration Release'
       #     publishTestResults: true
 
+      - task: DotNetCoreCLI@2
+        displayName:  Build UI Tests
+        inputs:
+          command: 'build'
+          projects: '$(projectPath)/*.csproj'
+          arguments: '--configuration Release'
+
       - task: VisualStudioTestPlatformInstaller@1
+        displayName: Run VS Test Installer
         inputs:
           packageFeedSelector: 'nugetOrg'
           versionSelector: 'latestStable'
 
       - task: VSTest@2
+        displayName:  Run UI Tests
         inputs:
           testSelector: 'testAssemblies'
           testAssemblyVer2: |

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -63,13 +63,19 @@ stages:
       #     arguments: '--configuration Release'
       #     publishTestResults: true
 
-      - task: DotNetCoreCLI@2
-        displayName:  Build UI Tests
-        inputs:
-          command: 'build'
-          projects: '$(projectPath)/*.csproj'
-          arguments: '--configuration Release'
+      # - task: DotNetCoreCLI@2
+      #   displayName:  Build UI Tests
+      #   inputs:
+      #     command: 'build'
+      #     projects: '$(projectPath)/*.csproj'
+      #     arguments: '--configuration Release'
 
+      - task: MSBuild@1
+        inputs:
+          solution: '$(projectPath)/*.csproj'
+          configuration: 'Release'
+          restoreNugetPackages: true
+      
       - task: VisualStudioTestPlatformInstaller@1
         displayName: Run VS Test Installer
         inputs:

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -84,7 +84,7 @@ stages:
             **\UISelenium.dll
             !**\*TestAdapter.dll
             !**\obj\**
-          searchFolder: '$(projectPath)'
+          searchFolder: '$(System.DefaultWorkingDirectory)'
           rerunFailedTests: true
           rerunMaxAttempts: '2'
           publishRunAttachments: True

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -63,6 +63,11 @@ stages:
       #     arguments: '--configuration Release'
       #     publishTestResults: true
 
+      - task: VisualStudioTestPlatformInstaller@1
+        inputs:
+          packageFeedSelector: 'nugetOrg'
+          versionSelector: 'latestPreRelease'
+
       - task: VSTest@2
         inputs:
           testSelector: 'testAssemblies'

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -66,7 +66,7 @@ stages:
       - task: VisualStudioTestPlatformInstaller@1
         inputs:
           packageFeedSelector: 'nugetOrg'
-          versionSelector: 'latestPreRelease'
+          versionSelector: 'latestStable'
 
       - task: VSTest@2
         inputs:

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -55,10 +55,22 @@ stages:
           Get-Content "$(projectPath)/appsettings.json"
         displayName: Print App Settings
 
-      - task: DotNetCoreCLI@2
-        displayName:  Run UI Tests
+      # - task: DotNetCoreCLI@2
+      #   displayName:  Run UI Tests
+      #   inputs:
+      #     command: test
+      #     projects: '$(projectPath)/*.csproj'
+      #     arguments: '--configuration Release'
+      #     publishTestResults: true
+
+      - task: VSTest@2
         inputs:
-          command: test
-          projects: '$(projectPath)/*.csproj'
-          arguments: '--configuration Release'
-          publishTestResults: true
+          testSelector: 'testAssemblies'
+          testAssemblyVer2: |
+            **\UISelenium.dll
+            !**\*TestAdapter.dll
+            !**\obj\**
+          searchFolder: '$(projectPath)'
+          rerunFailedTests: true
+          rerunMaxAttempts: '2'
+          publishRunAttachments: True


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-9588

### Change description ###

Replace botnet core with VSTEST task to support the retry of failing UI tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
