### PR TITLE
Update allocation test to use a different justice user

### DIFF
--- a/UI.NUnitVersion/Admin/WorkAllocation/AllocateHearingTests.cs
+++ b/UI.NUnitVersion/Admin/WorkAllocation/AllocateHearingTests.cs
@@ -13,7 +13,7 @@ public class AllocateHearingTests : AdminWebUiTest
         var dashboardPage = loginPage.Login(AdminLoginUsername, EnvConfigSettings.UserPassword);
 
         var manageWorkAllocationPage = dashboardPage.GoToManageWorkAllocation();
-        manageWorkAllocationPage.AllocateJusticeUserToHearing();
+        manageWorkAllocationPage.AllocateJusticeUserToHearing(justiceUserDisplayName:"Auto VHoteamleader1", justiceUserUsername:"auto.vhoteamlead1@hearings.reform.hmcts.net");
 
         Assert.Pass();
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Use a different justice user for work allocation test to avoid risk of overlapping with the delete justice user instance

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
