### PR TITLE
VIH-11008 Capture and output all accessibility results

### DIFF
--- a/UI.AutomationTests/CommonUiTest.cs
+++ b/UI.AutomationTests/CommonUiTest.cs
@@ -60,8 +60,6 @@ public abstract class CommonUiTest
 
     protected static void ReportAccessibility()
     {
-        AccessibilityResultCollection.CreateReports();
-        
         if (AccessibilityResultCollection.HasViolations())
         {
             Assert.Fail("Accessibility tests failed, please view the results in the reports");

--- a/UI.AutomationTests/CommonUiTest.cs
+++ b/UI.AutomationTests/CommonUiTest.cs
@@ -3,6 +3,7 @@ using BookingsApi.Client;
 using BookingsApi.Contract.V1.Requests;
 using BookingsApi.Contract.V1.Requests.Enums;
 using BookingsApi.Contract.V1.Responses;
+using UI.PageModels.Utilities;
 using UserApi.Client;
 
 namespace UI.AutomationTests;
@@ -55,6 +56,16 @@ public abstract class CommonUiTest
         await TestContext.Out.WriteLineAsync($"Using justice user for test {justiceUser.ContactEmail}");
 
         return justiceUser;
+    }
+
+    protected static void CheckAccessibility()
+    {
+        AccessibilityResultCollection.CreateReports();
+        
+        if (AccessibilityResultCollection.HasViolations())
+        {
+            Assert.Fail("Accessibility tests failed, please view the results in the reports");
+        }
     }
     
     [OneTimeTearDown]

--- a/UI.AutomationTests/CommonUiTest.cs
+++ b/UI.AutomationTests/CommonUiTest.cs
@@ -58,7 +58,7 @@ public abstract class CommonUiTest
         return justiceUser;
     }
 
-    protected static void CheckAccessibility()
+    protected static void ReportAccessibility()
     {
         AccessibilityResultCollection.CreateReports();
         

--- a/UI.AutomationTests/Video/EndToEndTest.cs
+++ b/UI.AutomationTests/Video/EndToEndTest.cs
@@ -111,7 +111,7 @@ public class EndToEndTest : VideoWebUiTest
         // sign out of each hearing
         SignOutAllUsers();
 
-        CheckAccessibility();
+        ReportAccessibility();
         Assert.Pass();
     }
 

--- a/UI.AutomationTests/Video/EndToEndTest.cs
+++ b/UI.AutomationTests/Video/EndToEndTest.cs
@@ -110,6 +110,8 @@ public class EndToEndTest : VideoWebUiTest
 
         // sign out of each hearing
         SignOutAllUsers();
+
+        CheckAccessibility();
         Assert.Pass();
     }
 

--- a/UI.AutomationTests/Video/VideoWebUiTest.cs
+++ b/UI.AutomationTests/Video/VideoWebUiTest.cs
@@ -4,6 +4,7 @@ using UI.PageModels.Pages.Video;
 using UI.PageModels.Pages.Video.Participant;
 using UI.PageModels.Pages.Video.QuickLink;
 using UI.PageModels.Pages.Video.Vho;
+using UI.PageModels.Utilities;
 using VideoApi.Client;
 using VideoApi.Contract.Enums;
 using VideoApi.Contract.Requests;
@@ -61,6 +62,7 @@ public abstract class VideoWebUiTest : CommonUiTest
             x.Driver.Terminate();
         });
         ParticipantDrivers.Clear();
+        AccessibilityResultCollection.Clear();
     }
     
     protected virtual async Task<ConferenceDetailsResponse> GetConference(Guid hearingId)

--- a/UI.PageModels/Pages/VhPage.cs
+++ b/UI.PageModels/Pages/VhPage.cs
@@ -40,7 +40,7 @@ public abstract class VhPage
         var axeBuilder = new AxeBuilder(Driver);
         var axeResult = axeBuilder.Analyze();
         var result = new AccessibilityResult(axeResult, Driver);
-        AccessibilityResultCollection.Add(result);
+        AccessibilityResultCollection.Capture(result);
     }
     
     protected virtual void ConfirmPageHasLoaded()

--- a/UI.PageModels/Pages/VhPage.cs
+++ b/UI.PageModels/Pages/VhPage.cs
@@ -1,7 +1,6 @@
 
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium.Support.UI;
-using Selenium.Axe;
 using SeleniumExtras.WaitHelpers;
 using UI.Common.Configuration;
 using UI.PageModels.Utilities;
@@ -37,10 +36,7 @@ public abstract class VhPage
     {
         ConfirmPageHasLoaded();
         if(!AccessibilityCheck || IsLoginPage || IgnoreAccessibilityForPage) return;
-        var axeBuilder = new AxeBuilder(Driver);
-        var axeResult = axeBuilder.Analyze();
-        var result = new AccessibilityResult(axeResult, Driver);
-        AccessibilityResultCollection.Capture(result);
+        AccessibilityResult.Capture(Driver);
     }
     
     protected virtual void ConfirmPageHasLoaded()

--- a/UI.PageModels/Utilities/AccessibilityReport.cs
+++ b/UI.PageModels/Utilities/AccessibilityReport.cs
@@ -1,0 +1,37 @@
+using Selenium.Axe;
+using UI.PageModels.Pages;
+
+namespace UI.PageModels.Utilities;
+
+public static class AccessibilityReport
+{
+    public static void Create(AccessibilityResult result, IWebDriver driver)
+    {
+        var filename = GenerateFilename();
+        CheckAndCreateDirectory(filename);
+        driver.CreateAxeHtmlReport(result.Result, filename, ReportTypes.Violations);
+    }
+    
+    private static string GenerateFilename()
+    {
+        var directory = Environment.GetEnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY") ?? string.Empty;
+        var testName = Environment.GetEnvironmentVariable(VhPage.VHTestNameKey);
+        directory = !string.IsNullOrEmpty(directory) ? Path.Join(directory, testName) : testName;
+
+        if (!string.IsNullOrEmpty(directory) && !directory.EndsWith('/'))
+            directory += "/";
+        
+        var filename = $"{directory}{Guid.NewGuid()}_AccessibilityReport.html";
+
+        return filename;
+    }
+
+    private static void CheckAndCreateDirectory(string filename)
+    {
+        var directory = Path.GetDirectoryName(filename) ?? string.Empty;
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+}

--- a/UI.PageModels/Utilities/AccessibilityResult.cs
+++ b/UI.PageModels/Utilities/AccessibilityResult.cs
@@ -1,0 +1,9 @@
+using Selenium.Axe;
+
+namespace UI.PageModels.Utilities;
+
+public class AccessibilityResult(AxeResult result, IWebDriver driver)
+{
+    public AxeResult Result { get; private set; } = result;
+    public IWebDriver Driver { get; private set; } = driver;
+}

--- a/UI.PageModels/Utilities/AccessibilityResult.cs
+++ b/UI.PageModels/Utilities/AccessibilityResult.cs
@@ -2,8 +2,25 @@ using Selenium.Axe;
 
 namespace UI.PageModels.Utilities;
 
-public class AccessibilityResult(AxeResult result, IWebDriver driver)
+public class AccessibilityResult
 {
-    public AxeResult Result { get; private set; } = result;
-    public IWebDriver Driver { get; private set; } = driver;
+    private AccessibilityResult(AxeResult axeResult)
+    {
+        Result = axeResult;
+    }
+    
+    public AxeResult Result { get; private set; }
+
+    /// <summary>
+    /// If the result has not already been captured, saves the result and creates a report
+    /// </summary>
+    public static void Capture(IWebDriver driver)
+    {
+        var axeBuilder = new AxeBuilder(driver);
+        var axeResult = axeBuilder.Analyze();
+        var result = new AccessibilityResult(axeResult);
+        
+        if (AccessibilityResultCollection.Add(result))
+            AccessibilityReport.Create(result, driver);
+    }
 }

--- a/UI.PageModels/Utilities/AccessibilityResultCollection.cs
+++ b/UI.PageModels/Utilities/AccessibilityResultCollection.cs
@@ -6,13 +6,15 @@ namespace UI.PageModels.Utilities;
 public static class AccessibilityResultCollection
 {
     private static List<AccessibilityResult> Results { get; } = [];
-    
-    public static void Add(AccessibilityResult result)
+
+    /// <summary>
+    /// If the result has not already been captured, saves the result and creates a report
+    /// </summary>
+    /// <param name="result"></param>
+    public static void Capture(AccessibilityResult result)
     {
-        var alreadyExists = Results.Find(r => r.Result.Url == result.Result.Url) != null;
-        if (alreadyExists) return;
-        
-        Results.Add(result);
+        if (!Add(result)) return;
+        CreateReport(result);
     }
 
     public static void Clear()
@@ -20,20 +22,27 @@ public static class AccessibilityResultCollection
         Results.Clear();
     }
 
-    public static void CreateReports()
+    public static void CreateReport(AccessibilityResult result)
     {
-        foreach (var result in Results)
-        {
-            var filename = GenerateFilename();
-            CheckAndCreateDirectory(filename);
-            result.Driver.CreateAxeHtmlReport(result.Result, filename, ReportTypes.Violations);
-        }
+        var filename = GenerateFilename();
+        CheckAndCreateDirectory(filename);
+        result.Driver.CreateAxeHtmlReport(result.Result, filename, ReportTypes.Violations);
     }
 
     public static bool HasViolations()
     {
         return Results.Any(r =>
             r.Result.Violations.Any(x => x.Impact != "minor"));
+    }
+    
+    private static bool Add(AccessibilityResult result)
+    {
+        var alreadyExists = Results.Find(r => r.Result.Url == result.Result.Url) != null;
+        if (alreadyExists) return false;
+        
+        Results.Add(result);
+
+        return true;
     }
     
     private static string GenerateFilename()

--- a/UI.PageModels/Utilities/AccessibilityResultCollection.cs
+++ b/UI.PageModels/Utilities/AccessibilityResultCollection.cs
@@ -1,0 +1,50 @@
+using Selenium.Axe;
+
+namespace UI.PageModels.Utilities;
+
+public static class AccessibilityResultCollection
+{
+    private static List<AccessibilityResult> Results { get; } = [];
+    
+    public static void Add(AccessibilityResult result)
+    {
+        var alreadyExists = Results.Find(r => r.Result.Url == result.Result.Url) != null;
+        if (alreadyExists) return;
+        
+        Results.Add(result);
+    }
+
+    public static void Clear()
+    {
+        Results.Clear();
+    }
+
+    public static void CreateReports()
+    {
+        foreach (var result in Results)
+        {
+            var filename = GenerateFilename();
+            result.Driver.CreateAxeHtmlReport(result.Result, filename, ReportTypes.Violations);
+        }
+        
+        // TODO merge the json into a single report
+    }
+
+    public static bool HasViolations()
+    {
+        return Results.Any(r =>
+            r.Result.Violations.Any(x => x.Impact != "minor"));
+    }
+    
+    private static string GenerateFilename()
+    {
+        var filename = $"{Guid.NewGuid()}_AccessibilityReport.html";
+        var stagingDir = Environment.GetEnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY");
+        if (!string.IsNullOrEmpty(stagingDir))
+        {
+            filename = Path.Join(stagingDir, filename);
+        }
+
+        return filename;
+    }
+}

--- a/UI.PageModels/Utilities/AccessibilityResultCollection.cs
+++ b/UI.PageModels/Utilities/AccessibilityResultCollection.cs
@@ -1,41 +1,10 @@
-using Selenium.Axe;
-using UI.PageModels.Pages;
-
 namespace UI.PageModels.Utilities;
 
 public static class AccessibilityResultCollection
 {
     private static List<AccessibilityResult> Results { get; } = [];
 
-    /// <summary>
-    /// If the result has not already been captured, saves the result and creates a report
-    /// </summary>
-    /// <param name="result"></param>
-    public static void Capture(AccessibilityResult result)
-    {
-        if (!Add(result)) return;
-        CreateReport(result);
-    }
-
-    public static void Clear()
-    {
-        Results.Clear();
-    }
-
-    public static void CreateReport(AccessibilityResult result)
-    {
-        var filename = GenerateFilename();
-        CheckAndCreateDirectory(filename);
-        result.Driver.CreateAxeHtmlReport(result.Result, filename, ReportTypes.Violations);
-    }
-
-    public static bool HasViolations()
-    {
-        return Results.Any(r =>
-            r.Result.Violations.Any(x => x.Impact != "minor"));
-    }
-    
-    private static bool Add(AccessibilityResult result)
+    public static bool Add(AccessibilityResult result)
     {
         var alreadyExists = Results.Find(r => r.Result.Url == result.Result.Url) != null;
         if (alreadyExists) return false;
@@ -45,26 +14,14 @@ public static class AccessibilityResultCollection
         return true;
     }
     
-    private static string GenerateFilename()
+    public static void Clear()
     {
-        var directory = Environment.GetEnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY") ?? string.Empty;
-        var testName = Environment.GetEnvironmentVariable(VhPage.VHTestNameKey);
-        directory = !string.IsNullOrEmpty(directory) ? Path.Join(directory, testName) : testName;
-
-        if (!string.IsNullOrEmpty(directory) && !directory.EndsWith('/'))
-            directory += "/";
-        
-        var filename = $"{directory}{Guid.NewGuid()}_AccessibilityReport.html";
-
-        return filename;
+        Results.Clear();
     }
 
-    private static void CheckAndCreateDirectory(string filename)
+    public static bool HasViolations()
     {
-        var directory = Path.GetDirectoryName(filename) ?? string.Empty;
-        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
+        return Results.Any(r =>
+            r.Result.Violations.Any(x => x.Impact != "minor"));
     }
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11008

### Change description
Currently accessibility tests abort as soon as they encounter a major violation.

This PR changes the accessibility tests to run all the way through regardless, and capture and output all the violations (one report per url). If there are any major violations, the test will fail at the end with an exception.

The reports are named with a guid instead of a url to avoid file path issues. 

![image](https://github.com/user-attachments/assets/8d02b69a-8724-4af5-8f98-b4248feb93f0)
![image](https://github.com/user-attachments/assets/1f7b9c20-7285-448d-96c3-838d2794dacf)
