### PR TITLE
VIH-11039 Fix for stale element reference error

### DIFF
--- a/UI.PageModels/Pages/VhPage.cs
+++ b/UI.PageModels/Pages/VhPage.cs
@@ -147,9 +147,9 @@ public abstract class VhPage
 
     private void TryWaitForClickable(By locator, int timeOut, bool withRefresh)
     {
-        var attempts = 0;
-        const int attemptLimit = 3;
-        while (attempts < attemptLimit)
+        const int maxAttempts = 3;
+
+        for (var attempts = 0; attempts < maxAttempts; attempts++)
         {
             try
             {
@@ -159,17 +159,18 @@ public abstract class VhPage
             }
             catch (StaleElementReferenceException)
             {
-                attempts++;
+                if (attempts == maxAttempts - 1) 
+                    throw;
             }
             catch (WebDriverTimeoutException)
             {
                 if (!withRefresh) throw;
                 Driver.Navigate().Refresh();
-                TryWaitForClickable(locator, timeOut, withRefresh: false);
-                return;
+                
+                if (attempts == maxAttempts - 1) 
+                    throw;
             }
         }
-        throw new StaleElementReferenceException("Element not clickable after multiple attempts");
     }
     
     protected void ClickElement(By locator, bool waitToBeClickable = true)


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11039

### Change description
Add a retry to relocate the element in the event of a stale element reference exception

Some of the video web tests are still failing intermittently due to pexip connectivity issues, but the stale element error should now be fixed
