### PR TITLE
VIH-11184 Use Case Number and Case Name to filter for emails

### DIFF
--- a/UI.AutomationTests/Admin/Booking/BookHearingTests.cs
+++ b/UI.AutomationTests/Admin/Booking/BookHearingTests.cs
@@ -74,7 +74,7 @@ public class BookHearingTests : AdminWebUiTest
         postBookingUnallocatedHearingsNextThirtyDays.Should()
             .BeGreaterThan(preBookingUnallocatedHearingsNextThirtyDays);
 
-        await ValidateEmailNotifications(newUser, _bookingDto.CaseName);
+        await ValidateEmailNotifications(newUser, _bookingDto.CaseName, _bookingDto.CaseNumber);
         
         dashboardPage.SignOut();
 
@@ -128,21 +128,21 @@ public class BookHearingTests : AdminWebUiTest
         Assert.Pass($"Booked a hearing with interpretation for {description}");
     }
     
-    private async Task ValidateEmailNotifications(BookingParticipantDto newUser, string caseName)
+    private async Task ValidateEmailNotifications(BookingParticipantDto newUser, string caseName, string caseNumber)
     {
         await EmailNotificationService.PullNotificationList();
         //Validate Judge email notification
-        await EmailNotificationService.ValidateEmailReceived(_bookingDto.Judge.Username, EmailTemplates.JudgeHearingConfirmation, caseName);
+        await EmailNotificationService.ValidateEmailReceived(_bookingDto.Judge.Username, EmailTemplates.JudgeHearingConfirmation, caseName, caseNumber);
         //Validate New User Participant email notification
-        await EmailNotificationService.ValidateEmailReceived(newUser.ContactEmail, EmailTemplates.FirstEmailAllNewUsers, caseName);
-        await EmailNotificationService.ValidateEmailReceived(newUser.ContactEmail, EmailTemplates.SecondEmailNewUserConfirmation, caseName);
+        await EmailNotificationService.ValidateEmailReceived(newUser.ContactEmail, EmailTemplates.FirstEmailAllNewUsers, caseName, caseNumber);
+        await EmailNotificationService.ValidateEmailReceived(newUser.ContactEmail, EmailTemplates.SecondEmailNewUserConfirmation, caseName, caseNumber);
         //Validate Other Participants email notification
         foreach (var participant in _bookingDto.Participants)
         {
             if (participant.Role == GenericTestRole.Representative)
-                await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.ExistingProfessionalConfirmation, caseName);
+                await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.ExistingProfessionalConfirmation, caseName, caseNumber);
             else
-                await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.ExistingParticipantConfirmation, caseName);
+                await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.ExistingParticipantConfirmation, caseName, caseNumber);
         }
     }
 }

--- a/UI.AutomationTests/Admin/Booking/EditMultiDayHearingTests.cs
+++ b/UI.AutomationTests/Admin/Booking/EditMultiDayHearingTests.cs
@@ -87,26 +87,27 @@ namespace UI.AutomationTests.Admin.Booking
             await EmailNotificationService.PullNotificationList();
             //original judge
             var caseName = hearingDto.CaseName;
-            await EmailNotificationService.ValidateEmailReceived(HearingTestData.JudgeUsername, EmailTemplates.JudgeHearingConfirmationMultiDay, caseName);
-            await EmailNotificationService.ValidateEmailReceived(HearingTestData.JudgeUsername, EmailTemplates.HearingAmendmentJudge, caseName);
+            var caseNumber = hearingDto.CaseNumber;
+            await EmailNotificationService.ValidateEmailReceived(HearingTestData.JudgeUsername, EmailTemplates.JudgeHearingConfirmationMultiDay, caseName, caseNumber);
+            await EmailNotificationService.ValidateEmailReceived(HearingTestData.JudgeUsername, EmailTemplates.HearingAmendmentJudge, caseName, caseNumber);
             //new judge
-            await EmailNotificationService.ValidateEmailReceived(hearingDto.Judge.Username, EmailTemplates.JudgeHearingConfirmation, caseName);
+            await EmailNotificationService.ValidateEmailReceived(hearingDto.Judge.Username, EmailTemplates.JudgeHearingConfirmation, caseName, caseNumber);
             //Validate New User Participant email notification
-            await EmailNotificationService.ValidateEmailReceived(hearingDto.NewParticipants[0].ContactEmail, EmailTemplates.FirstEmailAllNewUsers, caseName);
-            await EmailNotificationService.ValidateEmailReceived(hearingDto.NewParticipants[0].ContactEmail, EmailTemplates.SecondEmailNewUserConfirmation, caseName);
+            await EmailNotificationService.ValidateEmailReceived(hearingDto.NewParticipants[0].ContactEmail, EmailTemplates.FirstEmailAllNewUsers, caseName, caseNumber);
+            await EmailNotificationService.ValidateEmailReceived(hearingDto.NewParticipants[0].ContactEmail, EmailTemplates.SecondEmailNewUserConfirmation, caseName, caseNumber);
             //Validate Other Participants email notification
             foreach (var participant in hearingDto.Participants)
             {
                 if (participant.Role == GenericTestRole.Representative)
                 {
                     
-                    await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.ExistingProfessionalConfirmationMultiDay, caseName);
-                    await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.HearingAmendmentProfessional, caseName);
+                    await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.ExistingProfessionalConfirmationMultiDay, caseName, caseNumber);
+                    await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.HearingAmendmentProfessional, caseName, caseNumber);
                 }
                 else
                 {
-                    await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.ExistingParticipantConfirmationMultiDay, caseName);
-                    await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.HearingAmendment, caseName);
+                    await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.ExistingParticipantConfirmationMultiDay, caseName, caseNumber);
+                    await EmailNotificationService.ValidateEmailReceived(participant.ContactEmail, EmailTemplates.HearingAmendment, caseName, caseNumber);
                 }
             }
         }

--- a/UI.AutomationTests/Video/JudgeTests.cs
+++ b/UI.AutomationTests/Video/JudgeTests.cs
@@ -60,8 +60,6 @@ namespace UI.AutomationTests.Video
             var judgeWaitingRoomPage = judgeHearingListPage.SelectHearing(conference.Id);
 
             var judgeHearingRoomPage = judgeWaitingRoomPage.StartOrResumeHearing();
-            
-            Thread.Sleep(TimeSpan.FromSeconds(20)); // Allow time for the countdown to start
             judgeWaitingRoomPage = judgeHearingRoomPage.PauseHearing();
             judgeWaitingRoomPage.IsHearingPaused().Should().BeTrue();
             Assert.Pass();


### PR DESCRIPTION
### Jira link

VIH-11184

### Change description

Use Case Number and Case Name to filter for emails
Replace retry with PollyRetry


This change should handle the concurrent tests running to make sure the email assertion is against the current booking and not against a contact email and template id. If 2 bookings are made at the same time, we should make sure we're not passing on the second booking passing the first booking assertions.